### PR TITLE
remove country-code from requestVatNumber

### DIFF
--- a/app/code/community/Multibyte/VATFix/Helper/Data.php
+++ b/app/code/community/Multibyte/VATFix/Helper/Data.php
@@ -5,8 +5,8 @@
  * @package Multibyte_VatFix
  * @author Roman Hutterer <info@multibyte.at>
  */
-class Multibyte_VATFix_Helper_Data extends Mage_Customer_Helper_Data {
-
+class Multibyte_VATFix_Helper_Data extends Mage_Customer_Helper_Data
+{
     const VAT_VALIDATION_WSDL_URL = 'http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
 
     /**
@@ -17,13 +17,24 @@ class Multibyte_VATFix_Helper_Data extends Mage_Customer_Helper_Data {
      * @param string $requesterVatNumber
      * @return boolean
      */
-    public function checkVatNumber($countryCode, $vatNumber, $requesterCountryCode = '', $requesterVatNumber = '') {
+    public function checkVatNumber($countryCode, $vatNumber, $requesterCountryCode = '', $requesterVatNumber = '')
+    {
+        $storeId = Mage::app()->getStore()->getStoreId();
+
         //@RHU take the VAT without the first two signs (which are the countrycode)
-        if (Mage::getStoreConfig('customer/create_account/vatfix_enabled') && $this->includesCountryCode($vatNumber)) {
-            $newVatNumber = substr(str_replace(' ', '', trim($vatNumber)), 2);
-            Mage::log('Countrycode removed from VAT.(before:' . $vatNumber . '/after:' . $newVatNumber . ')');
+        if (Mage::getStoreConfigFlag('customer/create_account/vatfix_enabled', $storeId)) {
+            if ($this->includesCountryCode($vatNumber)) {
+                $newVatNumber = substr(str_replace(' ', '', trim($vatNumber)), 2);
+                Mage::log('Countrycode removed from customer-VAT.(before:' . $vatNumber . '/after:' . $newVatNumber . ')');
+            }
+
+            if ($requesterVatNumber !== '' && $this->includesCountryCode($requesterVatNumber)) {
+                $newRequesterVatNumber = substr(str_replace(' ', '', trim($requesterVatNumber)), 2);
+                Mage::log('Countrycode removed from requester-VAT.(before:' . $requesterVatNumber . '/after:' . $newRequesterVatNumber . ')');
+            }
         }
-        return parent::checkVatNumber($countryCode, $newVatNumber, $requesterCountryCode, $requesterVatNumber);
+
+        return parent::checkVatNumber($countryCode, $newVatNumber, $requesterCountryCode, $newRequesterVatNumber);
     }
 
     /**
@@ -32,7 +43,8 @@ class Multibyte_VATFix_Helper_Data extends Mage_Customer_Helper_Data {
      * @param boolean $trace
      * @return SoapClient
      */
-    protected function _createVatNumberValidationSoapClient($trace = false) {
+    protected function _createVatNumberValidationSoapClient($trace = false)
+    {
         return new SoapClient(self::VAT_VALIDATION_WSDL_URL, array('trace' => $trace));
     }
 
@@ -41,12 +53,13 @@ class Multibyte_VATFix_Helper_Data extends Mage_Customer_Helper_Data {
      * @param string $vatNumber
      * @return boolean
      */
-    public function includesCountryCode($vatNumber) {
+    public function includesCountryCode($vatNumber)
+    {
         $countryCode = substr(str_replace(' ', '', trim($vatNumber)), 0, 2);
         if (array_key_exists(strtoupper($countryCode), Mage::helper('multibyte_vatfix/countries')->getCountries())) {
             return true;
         }
+
         return;
     }
-
 }


### PR DESCRIPTION
validation fails on requests which include the requester VAT number which includes the country-code (e.g. in method Mage_Sales_Model_Observer->changeQuoteCustomerGroupId)